### PR TITLE
画像アップロードボタンの見た目を自由に変えられるようにする

### DIFF
--- a/_private/js/modules/react/components/form/Image.js
+++ b/_private/js/modules/react/components/form/Image.js
@@ -107,7 +107,7 @@ export default class Image extends Component {
   }
 
   onClickOriginalButton() {
-    ReactDOM.findDOMNode(this.refs.fileInput).click();
+    this.refs.fileInput.click();
   }
 
   getFileName(image){

--- a/_private/js/modules/react/components/form/Image.js
+++ b/_private/js/modules/react/components/form/Image.js
@@ -6,7 +6,6 @@ export default class Image extends Component {
     this.state = {
       naturalSizeList: {}
     }
-
     this.$wrapper = null;
   }
 
@@ -107,6 +106,10 @@ export default class Image extends Component {
     input.value = "";
   }
 
+  onClickOriginalButton() {
+    ReactDOM.findDOMNode(this.refs.fileInput).click();
+  }
+
   getFileName(image){
     if(image.file){
       return image.file.name;
@@ -124,7 +127,21 @@ export default class Image extends Component {
     }
     return (
       <div className="wrapper">
-        <input className="form-control" type="file" onChange={e => this.onChangeInput(e)}  {...inputFileProps} />
+        {(() => {
+          if(React.Children.count(this.props.children) > 0) {
+            return (
+              <div onClick={() => this.onClickOriginalButton()}>
+                <input style={{display: 'none'}} className="form-control" type="file" ref="fileInput" onChange={e => this.onChangeInput(e)}  {...inputFileProps} />
+                {this.props.children}
+              </div>
+            )
+          } else {
+            return (
+              <input className="form-control" type="file" onChange={e => this.onChangeInput(e)}  {...inputFileProps} />
+            )
+          }
+        })()}
+
         {descriptions.map((value, key) => {
           return <p key={key} className="description">{value}</p>
         })}

--- a/_private/js/modules/react/components/form/Image.js
+++ b/_private/js/modules/react/components/form/Image.js
@@ -130,7 +130,7 @@ export default class Image extends Component {
         {(() => {
           if(React.Children.count(this.props.children) > 0) {
             return (
-              <div onClick={() => this.onClickOriginalButton()}>
+              <div className="upload-trigger-wrapper" onClick={() => this.onClickOriginalButton()}>
                 <input style={{display: 'none'}} className="form-control" type="file" ref="fileInput" onChange={e => this.onChangeInput(e)}  {...inputFileProps} />
                 {this.props.children}
               </div>


### PR DESCRIPTION
## 概要
以下を可能にするためのPRです。
- `<input type=file>` の「選択されていません」 という表示を消したい
- input ボタンの見た目を自由に変えたい

## 使い方
Image のコンポーネント生成時に children を渡すと、それが input の代わりに表示されるようになります。
下記の例はHTMLタグを渡していますが、単に文字列を渡してもいけます。
```js
<ImageComponent
  data={{count: 1}}
  values={[]}
  onValueChange={e => this.props.onChangeImage(e.values[0])
>
  <button type="button" class="test-class">OriginalButtonSample</button>
</ImageComponent>
```

以下のように何も渡さなければ従来どおりの input が表示されます。
```js
<ImageComponent 
  data={{count: 1}}
  values={[]}
  onValueChange={e => this.props.onChangeImage(e.values[0])
/>
```

## 注意点
children に button タグを渡すときは、submit の挙動でページ遷移が起こらないように必ず `type="button"` を明示的に指定してください。