### PR TITLE
テキスト編集用コンポーネント修正

### DIFF
--- a/_private/js/modules/react/components/TextEditor.js
+++ b/_private/js/modules/react/components/TextEditor.js
@@ -44,6 +44,7 @@ export default class TextEditor extends Component {
         <input
           type="text"
           name={this.props.name}
+          value={this.props.value}
           placeholder={this.props.placeholder}
           onChange={(e) => this.onChange(e)}
           onKeyDown={(e) => this.onKeyDown(e)}

--- a/_private/js/modules/react/components/TextEditor.js
+++ b/_private/js/modules/react/components/TextEditor.js
@@ -30,22 +30,20 @@ export default class TextEditor extends Component {
       return (
         <textarea
           name={this.props.name}
+          value={this.props.value}
           rows={this.props.rows}
           cols={this.props.cols}
           placeholder={this.props.placeholder}
           onChange={(e) => this.onChange(e)}
           onKeyDown={(e) => this.onKeyDown(e)}
           onKeyUp={(e) => this.onKeyUp(e)}
-        >
-          {this.props.value}
-        </textarea>
+        />
       )
     } else {
       return (
         <input
           type="text"
           name={this.props.name}
-          value={this.props.value}
           placeholder={this.props.placeholder}
           onChange={(e) => this.onChange(e)}
           onKeyDown={(e) => this.onKeyDown(e)}


### PR DESCRIPTION
https://qiita.com/koba04/items/40cc217ab925ef651113#textarea

> テキストエリアの場合は、テキストフィールドと同じようにvalueに値を指定します。
HTMLの時と同じように<textarea>xxxx</textarea>とするとそれはdefaultValueとして扱われます。

テキストエリアと使用した際に値がうまく反映しなかったので調べたところ、値の指定方法が誤っていたので修正を行います。